### PR TITLE
Allow renaming of the session

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -14,16 +14,18 @@ Teamocil is a tool used to automatically create windows and splits in `tmux` wit
 
     # ~/.teamocil/sample.yml
 
-    windows:
-      - name: sample-window
-        splits:
-          - cmd: cd ~/Code/sample/www
-          - cmd:
-            - cd ~/Code/sample/www
-            - rails s
-            width: 50
-          - cmd: memcached -p 11211 -vv
-            height: 25
+    session:
+      name: sample-session
+      windows:
+        - name: sample-window
+          splits:
+            - cmd: cd ~/Code/sample/www
+            - cmd:
+              - cd ~/Code/sample/www
+              - rails s
+              width: 50
+            - cmd: memcached -p 11211 -vv
+              height: 25
 
 will create a new window named `sample-window` with a layout like this:
 

--- a/lib/teamocil/layout.rb
+++ b/lib/teamocil/layout.rb
@@ -16,7 +16,14 @@ module Teamocil
     def generate_commands # {{{
       output = []
 
-      @layout["windows"].each_with_index do |window, window_index|
+      if @layout["session"].nil?
+        windows = @layout["windows"]
+      else
+        output << "tmux rename-session #{@layout["session"]["name"]}"
+        windows = @layout["session"]["windows"]
+      end
+
+      windows.each_with_index do |window, window_index|
 
         if options.include?(:here) and window_index == 0
           output << "tmux rename-window #{window["name"]}"


### PR DESCRIPTION
This will allow user to easily reattach to an existing tmux session launched with Teamocil. Before, all sessions were named "window".

```
session:
    name: sample-session
    windows:
       [current config]
```

This new config is optional and your old config file will be just fine.
