### PR TITLE
Allow splits target to be explicitly set.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -33,6 +33,7 @@ Teamocil is a tool used to automatically create sessions, windows and splits in 
               width: 50
             - cmd: memcached -p 11211 -vv
               height: 25
+							target: bottom-right
 
 Running `$ teamocil sample` will rename the session to `sample-session` and create a new window named `sample-window` with a layout like this:
 

--- a/lib/teamocil/layout.rb
+++ b/lib/teamocil/layout.rb
@@ -34,14 +34,14 @@ module Teamocil
         window["splits"].each_with_index do |split, index|
           unless index == 0
             if split.include?("width")
-              output << "tmux split-window -h -p #{split["width"]}"
+              cmd = "tmux split-window -h -p #{split["width"]}"
+            elsif split.include?("height")
+              cmd = "tmux split-window -p #{split["height"]}"
             else
-              if split.include?("height")
-                output << "tmux split-window -p #{split["height"]}"
-              else
-                output << "tmux split-window"
-              end
+              cmd = "tmux split-window"
             end
+            cmd << " -t #{split["target"]}" if split.include?("target")
+            output << cmd
           end
 
           # Support single command splits, but treat it as an array nevertheless


### PR DESCRIPTION
I could not get teamocil to position the windows the way I wanted. This simple fix gives a little bit more flexibility as far as it goes with split positioning.
