### PR TITLE
Allow editing of layout without needing to be in a tmux session

### DIFF
--- a/lib/teamocil/cli.rb
+++ b/lib/teamocil/cli.rb
@@ -12,8 +12,6 @@ module Teamocil
     # @param argv [Hash] the command line parameters hash (usually `ARGV`).
     # @param env [Hash] the environment variables hash (usually `ENV`).
     def initialize(argv, env) # {{{
-      bail "You must be in a tmux session to use teamocil" unless env["TMUX"]
-
       parse_options! argv
       layout_path = File.join("#{env["HOME"]}", ".teamocil")
 
@@ -30,9 +28,12 @@ module Teamocil
 
       if @options[:edit]
         ::FileUtils.touch file unless File.exists?(file)
-        system("$EDITOR \"#{file}\"")
+
+        Kernel.system("$EDITOR \"#{file}\"")
       else
         bail "There is no file \"#{file}\"" unless File.exists?(file)
+        bail "You must be in a tmux session to use teamocil" unless env["TMUX"]
+
         parsed_layout = YAML.load_file(file)
         @layout = Teamocil::Layout.new(parsed_layout, @options)
         @layout.compile!

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -4,23 +4,40 @@ describe Teamocil::CLI do
 
   context "executing" do
 
-    before do # {{{
-      @fake_env = { "TMUX" => 1, "HOME" => File.join(File.dirname(__FILE__), "fixtures") }
-    end # }}}
+    context "not in tmux" do
 
-    it "creates a layout" do # {{{
-      @cli = Teamocil::CLI.new(["sample"], @fake_env)
-      @cli.layout.session.name.should == "sample"
-      @cli.layout.session.windows.length.should == 2
-      @cli.layout.session.windows.first.name.should == "foo"
-      @cli.layout.session.windows.last.name.should == "bar"
-    end # }}}
+      before do # {{{
+        @fake_env = { "TMUX" => 1, "HOME" => File.join(File.dirname(__FILE__), "fixtures") }
+      end # }}}
 
-    it "lists available layouts" do # {{{
-      @cli = Teamocil::CLI.new(["--list"], @fake_env)
-      @cli.layouts.should == ["sample", "sample-2"]
-    end # }}}
+      it "should allow editing" do # {{{
+        FileUtils.stub(:touch)
+        Kernel.should_receive(:system).with(any_args())
+
+        @cli = Teamocil::CLI.new(["--edit", "my-layout"], @fake_env)
+      end # }}}
+    end
+
+    context "in tmux" do
+
+      before do # {{{
+        @fake_env = { "TMUX" => 1, "HOME" => File.join(File.dirname(__FILE__), "fixtures") }
+      end # }}}
+
+      it "creates a layout" do # {{{
+        @cli = Teamocil::CLI.new(["sample"], @fake_env)
+        @cli.layout.session.name.should == "sample"
+        @cli.layout.session.windows.length.should == 2
+        @cli.layout.session.windows.first.name.should == "foo"
+        @cli.layout.session.windows.last.name.should == "bar"
+      end # }}}
+
+      it "lists available layouts" do # {{{
+        @cli = Teamocil::CLI.new(["--list"], @fake_env)
+        @cli.layouts.should == ["sample", "sample-2"]
+      end # }}}
+
+    end
 
   end
-
 end

--- a/teamocil.gemspec
+++ b/teamocil.gemspec
@@ -25,5 +25,4 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "yard"
   s.add_development_dependency "maruku"
-
 end


### PR DESCRIPTION
Before, you couldn't edit a layout without being in a tmux session. This patch allows editing of a layout outside of a tmux session and adds a test to ensure it works outside of a tmux session.
