### PR TITLE
add command generation options

### DIFF
--- a/lib/teamocil/layout/pane.rb
+++ b/lib/teamocil/layout/pane.rb
@@ -50,13 +50,13 @@ module Teamocil
         # Set the TEAMOCIL environment variable
         # depending on the shell set in ENV
         if ENV['SHELL'].scan(/fish/).empty?
-          @cmd.unshift "export TEAMOCIL=1"
+          @cmd.unshift "export TEAMOCIL=1" if @window.with_env_var
         else
           @cmd.unshift "set -gx TEAMOCIL 1"
         end
 
         # Execute each pane command
-        commands << "tmux send-keys -t #{@index} \"#{@cmd.flatten.compact.join("; ")}\""
+        commands << "tmux send-keys -t #{@index} \"#{@cmd.flatten.compact.join(@window.cmd_separator)}\""
         commands << "tmux send-keys -t #{@index} Enter"
 
         commands

--- a/lib/teamocil/layout/window.rb
+++ b/lib/teamocil/layout/window.rb
@@ -2,7 +2,7 @@ module Teamocil
   class Layout
     # This class represents a window within tmux
     class Window
-      attr_reader :filters, :root, :panes, :options, :index, :name, :clear, :layout
+      attr_reader :filters, :root, :panes, :options, :index, :name, :clear, :layout, :with_env_var, :cmd_separator
 
       # Initialize a new tmux window
       #
@@ -12,6 +12,8 @@ module Teamocil
       def initialize(session, index, attrs={})
         @name = attrs["name"] || "teamocil-window-#{index+1}"
         @root = attrs["root"] || "."
+        @with_env_var = attrs["with_env_var"] || (true if attrs["with_env_var"].nil?)
+        @cmd_separator = attrs["cmd_separator"] || "; "
         @clear = attrs["clear"] == true ? "clear" : nil
         @options = attrs["options"] || {}
         @layout = attrs["layout"]

--- a/spec/fixtures/layouts.yml
+++ b/spec/fixtures/layouts.yml
@@ -36,6 +36,30 @@ two-windows-with-filters:
         - cmd: "echo 'foo again'"
           width: 50
 
+two-windows-with-custom-command-options:
+  windows:
+    - name: "foo"
+      cmd_separator: "\n"
+      with_env_var: false
+      clear: true
+      root: "/foo"
+      layout: "tiled"
+      panes:
+        - cmd: "echo 'foo'"
+        - cmd: "echo 'foo again'"
+    - name: "bar"
+      cmd_separator: " && "
+      with_env_var: true
+      root: "/bar"
+      splits:
+        - cmd:
+          - "echo 'bar'"
+          - "echo 'bar in an array'"
+          target: bottom-right
+        - cmd: "echo 'bar again'"
+          focus: true
+          width: 50
+
 three-windows-within-a-session:
   session:
     name: "my awesome session"

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -208,5 +208,17 @@ describe Teamocil::Layout do
         commands.last.should == "tmux send-keys -t 2 Enter"
       end
     end
+
+    it "should not export TEAMOCIL = 1 env variable if disabled" do
+      @layout = Teamocil::Layout.new(layouts["two-windows-with-custom-command-options"], {})
+
+      session = @layout.compile!
+      commands = session.windows.first.generate_commands
+      commands[1][0].should == ["tmux send-keys -t 0 \"cd \"/foo\"\nclear\necho 'foo'\"", "tmux send-keys -t 0 Enter", "tmux select-layout \"tiled\""]
+      commands[1][1].should == ["tmux split-window", "tmux send-keys -t 1 \"cd \"/foo\"\nclear\necho 'foo again'\"", "tmux send-keys -t 1 Enter", "tmux select-layout \"tiled\""]
+
+      commands = session.windows[1].generate_commands
+      commands[1][0].should == ["tmux send-keys -t 0 \"export TEAMOCIL=1 && cd \"/bar\" && echo 'bar' && echo 'bar in an array'\"", "tmux send-keys -t 0 Enter"]
+    end
   end
 end


### PR DESCRIPTION
This permits to avoid looong commands in your shell history.
Just explode a long suite of command by replacing `&&` with `\n`.
Also permits to not export `TEAMOCIL=1` env variable.

Just configure your window like that:

``` yaml

session:
    name: <%= File.basename(Dir.getwd) %>
    windows:
        - 
            cmd_separator: "\n"
            with_env_var: false
            name: editor
            splits:
                - { cmd: vim }


```
