### PR TITLE
Added an option to launch tmux with teamocil layouts

### DIFF
--- a/lib/teamocil/cli.rb
+++ b/lib/teamocil/cli.rb
@@ -31,7 +31,6 @@ module Teamocil
         Kernel.system("cat \"#{file}\"")
       else
         bail "There is no file \"#{file}\"" unless File.exists?(file)
-        bail "You must be in a tmux session to use teamocil" unless env["TMUX"]
 
         yaml = ERB.new(File.read(file)).result
 
@@ -42,7 +41,9 @@ module Teamocil
         rescue Teamocil::Error::LayoutError => e
           bail e.message
         end
-        @layout.execute_commands(@layout.generate_commands)
+        commands = @layout.generate_commands 
+        commands << @layout.attach_to_tmux unless env["TMUX"]
+        @layout.execute_commands(commands)
       end
     end
 

--- a/lib/teamocil/layout.rb
+++ b/lib/teamocil/layout.rb
@@ -41,5 +41,10 @@ module Teamocil
     def execute_commands(commands)
       `#{commands.join("; ")}`
     end
+
+    # Attach to session
+    def attach_to_tmux
+        "tmux -2 attach-session -t \"#{@session.name}\""
+    end
   end
 end

--- a/lib/teamocil/layout/session.rb
+++ b/lib/teamocil/layout/session.rb
@@ -21,7 +21,15 @@ module Teamocil
       # @return [Array]
       def generate_commands
         commands = []
-        commands << "tmux rename-session \"#{@name}\"" unless @name.nil?
+        unless ENV["TMUX"]
+            unless @name.nil?
+                commands << "tmux new-session -d -s #{@name}"
+            else
+                commands << "tmux new-session"
+            end
+        else
+            commands << "tmux rename-session \"#{@name}\"" unless @name.nil?
+        end
         commands << @windows.map(&:generate_commands)
       end
 


### PR DESCRIPTION
Instead of launching tmux and execute teamocil, now you can just type teamocil normally and tmux will be launched with the layout specified.
