### PR TITLE
Filename as fallback name 

### DIFF
--- a/lib/teamocil/cli.rb
+++ b/lib/teamocil/cli.rb
@@ -37,7 +37,7 @@ module Teamocil
         bail "You must be in a tmux session to use teamocil." unless env["TMUX"]
 
         conf = YAML.load(ERB.new(File.read(file)).result)
-        conf["session"]["name"] = argv[0] unless conf["session"]["name"]
+        conf["session"]["name"] ||= argv[0]
 
         @layout = Teamocil::Layout.new(conf, @options)
 


### PR DESCRIPTION
As discussed here: https://github.com/remiprev/teamocil/pull/33
Tests pass, moved the test for the name setting into `cli_spec.rb` and updated it accordingly.
