### PR TITLE
Travis to test multiple version of tmux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,19 @@
+language: ruby
 rvm: 1.9.2
+env:
+  - TMUX_VERSION=master
+  - TMUX_VERSION=1.8
+  - TMUX_VERSION=1.7
+  - TMUX_VERSION=1.6
+  - TMUX_VERSION=1.5
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libevent-dev libncurses-dev
+  - git clone git://git.code.sf.net/p/tmux/tmux-code tmux
+  - cd tmux
+  - git checkout $TMUX_VERSION
+  - sh autogen.sh
+  - ./configure && make && sudo make install
+  - cd ..
+  - tmux -V
 script: "bundle exec rake spec"


### PR DESCRIPTION
Howdy,

Testing of teamocil on multiple versions of tmux using [build matrix](http://about.travis-ci.org/docs/user/build-configuration/#The-Build-Matrix).

Here is a preview of the test matrix: https://travis-ci.org/tony/teamocil/builds/12658860

It is currently set to test versions 1.5 - 1.8 and the latest codebase.

You can allow versions to be tested and fail optionally with:

``` yaml
matrix:
  allow_failures:
    - env: TMUX_VERSION=1.5
```

1.5 could be any `env` variable set.
