### PR TITLE
Don't rename the session when its name is nil

### DIFF
--- a/lib/teamocil/layout/session.rb
+++ b/lib/teamocil/layout/session.rb
@@ -10,7 +10,11 @@ module Teamocil
       # @param attrs [Hash] the session data from the layout file
       def initialize(options, attrs={})
         raise Teamocil::Error::LayoutError.new("You must specify a `windows` or `session` key for your layout.") unless attrs["windows"]
-        @name = attrs["name"] || "teamocil-session-#{rand(10000) + 1}"
+        @name = if attrs.has_key? "name"
+                  attrs["name"]
+                else
+                  "teamocil-session-#{rand(10000) + 1}"
+                end
         @windows = attrs["windows"].each_with_index.map { |window, window_index| Window.new(self, window_index, window) }
         @options = options
       end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -74,6 +74,12 @@ describe Teamocil::CLI do
         expect { @cli = Teamocil::CLI.new(["sample"], @fake_env) }.to raise_error SystemExit
         Teamocil::CLI.messages.should include("There is no file \"#{@fake_env["TEAMOCIL_PATH"]}/sample.yml\".")
       end
+
+      it "creates a layout from a specific file without renaming it" do
+        @cli = Teamocil::CLI.new(["--layout", "./spec/fixtures/.my-fancy-layouts-directory/sample_nil_name.yml"], @fake_env)
+        @cli.layout.session.name.should be_nil
+      end
+
     end
   end
 end

--- a/spec/fixtures/.my-fancy-layouts-directory/sample_nil_name.yml
+++ b/spec/fixtures/.my-fancy-layouts-directory/sample_nil_name.yml
@@ -1,0 +1,10 @@
+session:
+  name: ~
+  root: ~
+  windows:
+    - name: <%= "foo" %>
+      panes:
+      - cmd: "pwd"
+    - name: "bar"
+      panes:
+      - cmd: "pwd"

--- a/spec/fixtures/layouts.yml
+++ b/spec/fixtures/layouts.yml
@@ -74,3 +74,11 @@ three-windows-within-a-session:
       - name: "third window"
         panes:
         - cmd: "echo 'foo'"
+
+unnamed-session:
+  session:
+    name: ~
+    windows:
+      - name: "first window"
+        panes:
+        - cmd: "echo 'foo'"

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -159,6 +159,12 @@ describe Teamocil::Layout do
         session = layout.compile!
         session.name.should match /teamocil-session-\d+/
       end
+
+      it "should not assign a random name if nil is provided" do
+        layout = Teamocil::Layout.new(layouts["unnamed-session"], {})
+        session = layout.compile!
+        session.name.should be_nil
+      end
     end
   end
 


### PR DESCRIPTION
If I want a specific Teamocil session to not be renamed, I should be able to set the sessions name to nil (aka ~) in the yml conf file.
