### PR TITLE
Adds prefix_with_space layout option

### DIFF
--- a/lib/teamocil/layout/pane.rb
+++ b/lib/teamocil/layout/pane.rb
@@ -55,6 +55,8 @@ module Teamocil
           @cmd.unshift "set -gx TEAMOCIL 1"
         end
 
+        @cmd[0] = " " + @cmd[0] if @window.prefix_with_space
+
         # Execute each pane command
         commands << "tmux send-keys -t #{@index} \"#{@cmd.flatten.compact.join(@window.cmd_separator)}\""
         commands << "tmux send-keys -t #{@index} Enter"

--- a/lib/teamocil/layout/window.rb
+++ b/lib/teamocil/layout/window.rb
@@ -2,7 +2,7 @@ module Teamocil
   class Layout
     # This class represents a window within tmux
     class Window
-      attr_reader :filters, :focus, :root, :panes, :options, :index, :name, :clear, :layout, :with_env_var, :cmd_separator
+      attr_reader :filters, :focus, :root, :panes, :options, :index, :name, :clear, :layout, :with_env_var, :cmd_separator, :prefix_with_space
 
       # Initialize a new tmux window
       #
@@ -13,6 +13,7 @@ module Teamocil
         @name = attrs["name"] || "teamocil-window-#{index+1}"
         @root = attrs["root"] || "."
         @with_env_var = attrs["with_env_var"] || (true if attrs["with_env_var"].nil?)
+        @prefix_with_space = attrs["prefix_with_space"] || (false if attrs["prefix_with_space"].nil?)
         @cmd_separator = attrs["cmd_separator"] || "; "
         @clear = attrs["clear"] == true ? "clear" : nil
         @options = attrs["options"] || {}

--- a/spec/fixtures/layouts.yml
+++ b/spec/fixtures/layouts.yml
@@ -61,6 +61,17 @@ two-windows-with-custom-command-options:
           focus: true
           width: 50
 
+two-windows-with-prefix-space-option:
+  windows:
+    - name: "foo"
+      prefix_with_space: true
+      panes:
+        - cmd: "foo"
+    - name: "bar"
+      prefix_with_space: false
+      panes:
+        - cmd: "bar"
+
 three-windows-within-a-session:
   session:
     name: "my awesome session"

--- a/spec/layout_spec.rb
+++ b/spec/layout_spec.rb
@@ -225,5 +225,16 @@ describe Teamocil::Layout do
       commands = session.windows[1].generate_commands
       commands[1][0].should == ["tmux send-keys -t 0 \"export TEAMOCIL=1 && cd \"/bar\" && echo 'bar' && echo 'bar in an array'\"", "tmux send-keys -t 0 Enter"]
     end
+
+    it "should use a prefix with a space if it is enabled" do
+      @layout = Teamocil::Layout.new(layouts["two-windows-with-prefix-space-option"], {})
+
+      session = @layout.compile!
+      commands = session.windows[0].generate_commands
+      commands[1][0][0].should =~ / export TEAMOCIL=1; cd "."; foo/
+
+      commands = session.windows[1].generate_commands
+      commands[1][0][0].should =~ /export TEAMOCIL=1; cd "."; bar/
+    end
   end
 end


### PR DESCRIPTION
This adds a prefix_with_space option to layouts. This allows shells to avoid adding commands to the command history (i.e. using bash's `ignorespace` option).

This option might belong better as a root option, but I wanted to get some input first. Also, prefix_with_space is kinda lame, need to think of a better name...
