### PR TITLE
add expand_path to handle homedirs

### DIFF
--- a/lib/teamocil/tmux/window.rb
+++ b/lib/teamocil/tmux/window.rb
@@ -4,6 +4,10 @@ module Teamocil
       def initialize(object)
         super
 
+        # Expand homedir
+        expanded_root = File.expand_path(root.to_s)
+        self.root = expanded_root.to_s
+
         self.panes ||= splits
         self.panes = panes.each_with_index.map do |pane, index|
           # Support single command instead of `commands` key in Hash
@@ -14,7 +18,7 @@ module Teamocil
           pane.merge! first: index.zero?
 
           # Panes need know the window root directory
-          pane.merge! root: root
+          pane.merge! root: self.root
 
           Teamocil::Tmux::Pane.new(pane)
         end


### PR DESCRIPTION
Hi,
I just gem updated to the latest release and I noticed the tilde home dir didn't work as intended, so added this quick fix.

---

  windows:
    - name: foo
    - root: ~/path/to/foo

I'm not a ruby dev, so hope this patch is the right code in the right place :)
