### PR TITLE
Fix issue when no pane are specified

### DIFF
--- a/lib/teamocil/tmux/window.rb
+++ b/lib/teamocil/tmux/window.rb
@@ -7,7 +7,7 @@ module Teamocil
         # Make sure paths like `~/foo/bar` work
         self.root = File.expand_path(root) if root
 
-        self.panes ||= splits
+        self.panes ||= []
         self.panes = panes.each_with_index.map do |pane, index|
           # Support single command instead of `commands` key in Hash
           pane = { commands: [pane] } if pane.is_a?(String)


### PR DESCRIPTION
I don't use _panes_ in my tmux configuration, each of my _windows_ only have the main _pane_. This was creating an issue where `self.panes` was `nil`.

Teamocil was trying to run the `splits` method which doesn't seem to exist. I've replaced the assignment with an empty Array.

Not sure it's the correct way to fix it but it works perfectly for my situation.
