### PR TITLE
Select layout after each pane (Fixes #87)

### DIFF
--- a/lib/teamocil/tmux/pane.rb
+++ b/lib/teamocil/tmux/pane.rb
@@ -1,11 +1,12 @@
 module Teamocil
   module Tmux
-    class Pane < ClosedStruct.new(:index, :root, :commands, :focus)
+    class Pane < ClosedStruct.new(:index, :root, :commands, :focus, :layout)
       def as_tmux
         [].tap do |tmux|
           tmux << Teamocil::Command::SplitWindow.new(root: root) unless first?
           tmux << Teamocil::Command::SendKeysToPane.new(index: internal_index, keys: commands.join('; ')) if commands
           tmux << Teamocil::Command::SendKeysToPane.new(index: internal_index, keys: 'Enter')
+          tmux << Teamocil::Command::SelectLayout.new(layout: layout) if layout
         end
       end
 

--- a/lib/teamocil/tmux/window.rb
+++ b/lib/teamocil/tmux/window.rb
@@ -18,6 +18,9 @@ module Teamocil
           # Panes need know the window root directory
           pane.merge! root: root
 
+          # Panes need know the window layout
+          pane.merge! layout: layout
+
           Teamocil::Tmux::Pane.new(pane)
         end
       end
@@ -39,9 +42,6 @@ module Teamocil
 
           # Execute all panes commands
           tmux << panes.map(&:as_tmux).flatten
-
-          # Select the window layout
-          tmux << Teamocil::Command::SelectLayout.new(layout: layout) if layout
 
           # Set the focus on the right pane or the first one
           focused_pane = panes.find(&:focus)

--- a/spec/teamocil/tmux/pane_spec.rb
+++ b/spec/teamocil/tmux/pane_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Teamocil::Tmux::Pane do
   describe :as_tmux do
-    let(:pane) { Teamocil::Tmux::Pane.new(commands: commands, root: root, index: index, focus: focus) }
+    let(:pane) { Teamocil::Tmux::Pane.new(commands: commands, root: root, index: index, focus: focus, layout: layout) }
     let(:as_tmux) { pane.as_tmux }
     let(:pane_base_index) { Random.rand(0..100) }
 
@@ -13,6 +13,7 @@ RSpec.describe Teamocil::Tmux::Pane do
     # Pane attributes
     let(:commands) { %w(foo bar) }
     let(:root) { '/tmp' }
+    let(:layout) { 'tiled' }
     let(:focus) { true }
 
     context 'for first pane' do
@@ -21,7 +22,8 @@ RSpec.describe Teamocil::Tmux::Pane do
       it do
         expect(as_tmux).to eql [
           Teamocil::Command::SendKeysToPane.new(index: pane_base_index, keys: 'foo; bar'),
-          Teamocil::Command::SendKeysToPane.new(index: pane_base_index, keys: 'Enter')
+          Teamocil::Command::SendKeysToPane.new(index: pane_base_index, keys: 'Enter'),
+          Teamocil::Command::SelectLayout.new(layout: layout)
         ]
       end
     end
@@ -33,7 +35,8 @@ RSpec.describe Teamocil::Tmux::Pane do
         expect(as_tmux).to eql [
           Teamocil::Command::SplitWindow.new(root: root),
           Teamocil::Command::SendKeysToPane.new(index: pane_base_index + index, keys: 'foo; bar'),
-          Teamocil::Command::SendKeysToPane.new(index: pane_base_index + index, keys: 'Enter')
+          Teamocil::Command::SendKeysToPane.new(index: pane_base_index + index, keys: 'Enter'),
+          Teamocil::Command::SelectLayout.new(layout: layout)
         ]
       end
     end

--- a/spec/teamocil/tmux/window_spec.rb
+++ b/spec/teamocil/tmux/window_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Teamocil::Tmux::Window do
         Teamocil::Command::NewWindow.new(name: name),
         Teamocil::Command::SendKeysToPane.new(index: pane_base_index, keys: 'foo; omg'),
         Teamocil::Command::SendKeysToPane.new(index: pane_base_index, keys: 'Enter'),
+        Teamocil::Command::SelectLayout.new(layout: layout),
         Teamocil::Command::SplitWindow.new,
         Teamocil::Command::SendKeysToPane.new(index: pane_base_index + 1, keys: 'bar'),
         Teamocil::Command::SendKeysToPane.new(index: pane_base_index + 1, keys: 'Enter'),


### PR DESCRIPTION
Instead of sending the `select-layout` command after creating all the panes, we now send it after each new pane.