### PR TITLE
Prevent calling a method on first pane if we have no panes (Fixes #95)

### DIFF
--- a/lib/teamocil/tmux/window.rb
+++ b/lib/teamocil/tmux/window.rb
@@ -87,9 +87,10 @@ module Teamocil
 
       def change_working_directory_commands
         return [] unless root
+        pane_index = panes.any? ? panes.first.internal_index : Teamocil::Tmux::Pane.pane_base_index
 
         [%(cd "#{root}"), 'Enter'].map do |keys|
-          Teamocil::Command::SendKeysToPane.new(index: panes.first.internal_index, keys: keys)
+          Teamocil::Command::SendKeysToPane.new(index: pane_index, keys: keys)
         end
       end
 


### PR DESCRIPTION
This prevents an error in an edge case for a layout where:

* the layout’s first window has no panes
* the layout is created with the `--here` flag

Thanks to @rewinfrey for the investigation work! 😄 