### PR TITLE
Renames window prior to changing directory with --here option.

### DIFF
--- a/lib/teamocil/tmux/window.rb
+++ b/lib/teamocil/tmux/window.rb
@@ -66,7 +66,7 @@ module Teamocil
 
       def spawn_window_commands
         if Teamocil.options[:here] && first?
-          change_working_directory_commands << Teamocil::Command::RenameWindow.new(name: name)
+          change_working_directory_commands.unshift(Teamocil::Command::RenameWindow.new(name: name))
         else
           Teamocil::Command::NewWindow.new(name: name, root: root)
         end

--- a/spec/teamocil/tmux/window_spec.rb
+++ b/spec/teamocil/tmux/window_spec.rb
@@ -130,9 +130,9 @@ RSpec.describe Teamocil::Tmux::Window do
 
       it do
         expect(as_tmux).to eql [
+          Teamocil::Command::RenameWindow.new(name: name),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'cd "/tmp"'),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
-          Teamocil::Command::RenameWindow.new(name: name),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo; omg'),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
           Teamocil::Command::SplitWindow.new(name: name, root: root),


### PR DESCRIPTION
Per #104, there is a bug where the directory won't change when using the
--here option, specifically when specifying a root for the first pane.
This resolves the issue by moving the rename window command to the front
of the commands queue.