### PR TITLE
Quote index of selected pane

### DIFF
--- a/lib/teamocil/command/select_pane.rb
+++ b/lib/teamocil/command/select_pane.rb
@@ -2,7 +2,7 @@ module Teamocil
   module Command
     class SelectPane < ClosedStruct.new(:index)
       def to_s
-        "select-pane -t #{index}"
+        "select-pane -t '#{index}'"
       end
     end
   end


### PR DESCRIPTION
This fixes pane focusing in cases where the window name and/or the
pane name contain spaces.

From looking around the rest of the code in `lib/teamocil/commands`, it appears there may be some other commands that ought to single-quote values to avoid issues with spaces in window/pane names. Perhaps a more holistic approach is in order?

Fixes #114.