### PR TITLE
Default value for $EDITOR

### DIFF
--- a/lib/teamocil/layout.rb
+++ b/lib/teamocil/layout.rb
@@ -13,7 +13,7 @@ module Teamocil
     end
 
     def edit!
-      Teamocil.system("$EDITOR #{path}")
+      Teamocil.system("${EDITOR:-vi} #{path}")
     end
 
     def self.print_available_layouts(directory: nil)

--- a/spec/teamocil/layout_spec.rb
+++ b/spec/teamocil/layout_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Teamocil::Layout do
     let(:path) { double('Path') }
 
     before do
-      expect(Teamocil).to receive(:system).with("$EDITOR #{path}")
+      expect(Teamocil).to receive(:system).with("${EDITOR:-vi} #{path}")
     end
 
     specify { edit! }


### PR DESCRIPTION
If the _EDITOR_ environment variable is not defined it's raised a **Permission denied** error, which is not associated with the file that the user pretends to edit