### PR TITLE
Substitute environment variables in root path

### DIFF
--- a/lib/teamocil/tmux/window.rb
+++ b/lib/teamocil/tmux/window.rb
@@ -1,11 +1,13 @@
 module Teamocil
   module Tmux
     class Window < ClosedStruct.new(:index, :root, :focus, :layout, :name, :panes, :options)
+      ENVIRONMENT_VARIABLES_REGEX = /\$([a-zA-Z_]+[a-zA-Z0-9_]*)|\$\{(.+)\}/
+
       def initialize(object)
         super
 
         # Make sure paths like `~/foo/bar` work
-        self.root = File.expand_path(root) if root
+        self.root = File.expand_path(root.gsub(ENVIRONMENT_VARIABLES_REGEX) { ENV[$1 || $2] }) if root
 
         self.options ||= {}
         self.panes ||= []

--- a/lib/teamocil/tmux/window.rb
+++ b/lib/teamocil/tmux/window.rb
@@ -100,7 +100,6 @@ module Teamocil
       end
 
       def substitue_env_vars
-        return nil unless root
         match = root.match(ENVIRONMENT_VARIABLES_REGEX)
         return root unless match
         root.gsub(ENVIRONMENT_VARIABLES_REGEX, ENV[match.captures[0] || match.captures[1]])


### PR DESCRIPTION
One can now do:
```yaml
windows:
    - name: "vim"
      root: "$PROJECT_DIR/Ruby/teamocil"
      .........
```
* The regular expression only checks for the format $VAR and ${VAR} and replaces them with their respective value from the ENV hash