### PR TITLE
added support for home directory which contains white space(s)

### DIFF
--- a/lib/teamocil/cli.rb
+++ b/lib/teamocil/cli.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module Teamocil
   class CLI < ClosedStruct.new(:arguments, :environment)
     DIRECTORY = '$HOME/.teamocil'
@@ -24,7 +26,7 @@ module Teamocil
   private
 
     def root
-      DIRECTORY.sub('$HOME', environment['HOME'])
+      Shellwords.shellescape DIRECTORY.sub('$HOME', environment['HOME'])
     end
 
     def layout_file_path


### PR DESCRIPTION
when trying to load the layout file from $HOME/.teamocil, teamocil will fail if the home directory contains white space(s). For example: /Users/my first last/.teamocil
