### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+cache: bundler
+
 rvm:
   - 2.0
   - 2.1


### PR DESCRIPTION
Would be interested to know why bundler cache hasn't been enabled on Travis. Thank you.